### PR TITLE
refresh the engine info on second pass

### DIFF
--- a/t/EngineInfo.t
+++ b/t/EngineInfo.t
@@ -39,9 +39,14 @@ gpgme_set_engine_info(
    '/baz',
 );
 
+$info = GPGME::FFI::EngineInfo->new;
+$error = gpgme_get_engine_info($info);
+$protocol_count = 0;
 
-for my $info (@info) {
+while($info = $info->next) {
+   push @info, $info;
    no warnings 'uninitialized';
+   $protocol_count++;
 
    note(
       join "\n",


### PR DESCRIPTION
Looks like the call to gpgme_set_engine_info was fine, but you were displaying the old engine info rather than refreshing it.  With this change I get:

```
twin% prove -lv t/EngineInfo.t
t/EngineInfo.t ..
# ---
#   protocol:    OpenPGP
#   file_name:   /usr/bin/gpg2
#   version:     2.0.26
#   req_version: 1.4.0
#   home_dir:
# ---
#   protocol:    CMS
#   file_name:   /usr/bin/gpgsm
#   version:
#   req_version: 2.0.4
#   home_dir:
# ---
#   protocol:    GPGCONF
#   file_name:   /usr/bin/gpgconf
#   version:     2.0.26
#   req_version: 2.0.4
#   home_dir:
# ---
#   protocol:    Assuan
#   file_name:   /home/ollisg/.gnupg/S.gpg-agent
#   version:     1.0
#   req_version: 1.0
#   home_dir:    !GPG_AGENT
# ---
#   protocol:    Spawn
#   file_name:   /nonexistent
#   version:     1.0
#   req_version: 1.0
#   home_dir:
ok 1 - at least one protocol supported
# ---
#   protocol:    OpenPGP
#   file_name:   /foo/bar
#   version:
#   req_version: 1.4.0
#   home_dir:    /baz
# ---
#   protocol:    CMS
#   file_name:   /usr/bin/gpgsm
#   version:
#   req_version: 2.0.4
#   home_dir:
# ---
#   protocol:    GPGCONF
#   file_name:   /usr/bin/gpgconf
#   version:     2.0.26
#   req_version: 2.0.4
#   home_dir:
# ---
#   protocol:    Assuan
#   file_name:   /home/ollisg/.gnupg/S.gpg-agent
#   version:     1.0
#   req_version: 1.0
#   home_dir:    !GPG_AGENT
# ---
#   protocol:    Spawn
#   file_name:   /nonexistent
#   version:     1.0
#   req_version: 1.0
#   home_dir:
1..1
ok
All tests successful.
Files=1, Tests=1,  0 wallclock secs ( 0.03 usr  0.00 sys +  0.08 cusr  0.00 csys =  0.11 CPU)
Result: PASS
```
